### PR TITLE
Fix bug: _extract_EyeTrackingMethod

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         args: [--config, pyproject.toml]
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     -   id: codespell
         args: [--toml, pyproject.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         args: [--profile, black]
 
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.16.0
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]

--- a/eye2bids/_base.py
+++ b/eye2bids/_base.py
@@ -82,6 +82,7 @@ class BasePhysioJson(dict[str, Any]):
     def __init__(self, manufacturer: str, metadata: dict[str, Any] | None = None) -> None:
 
         self["Manufacturer"] = manufacturer
+        self["PhysioType"] = "eyetrack"
 
         self["Columns"] = ["x_coordinate", "y_coordinate", "pupil_size", "timestamp"]
         self["timestamp"] = {

--- a/eye2bids/_base.py
+++ b/eye2bids/_base.py
@@ -78,6 +78,7 @@ class BasePhysioJson(dict[str, Any]):
     input_file: Path
     has_validation: bool
     two_eyes: bool
+    has_calibration: bool
 
     def __init__(self, manufacturer: str, metadata: dict[str, Any] | None = None) -> None:
 

--- a/eye2bids/edf2bids.py
+++ b/eye2bids/edf2bids.py
@@ -127,6 +127,9 @@ def _2eyesmode(df: pd.DataFrame) -> bool:
 def _calibrations(df: pd.DataFrame) -> pd.DataFrame:
     return df[df[3] == "CALIBRATION"]
 
+def _has_calibration(df: pd.DataFrame) -> bool:
+    return not _calibrations(df).empty
+
 
 def _extract_CalibrationType(df: pd.DataFrame) -> list[int]:
     return _calibrations(df).iloc[0:1, 2:3].to_string(header=False, index=False)
@@ -422,15 +425,18 @@ def generate_physio_json(
     base_json.input_file = input_file
     base_json.has_validation = _has_validation(df_ms_reduced)
     base_json.two_eyes = _2eyesmode(df_ms_reduced)
+    base_json.has_calibration = _has_calibration(df_ms_reduced)
 
     base_json["ManufacturersModelName"] = _extract_ManufacturersModelName(events)
     base_json["DeviceSerialNumber"] = _extract_DeviceSerialNumber(events)
-    base_json["EyeTrackingMethod"] = _extract_EyeTrackingMethod(events)
     base_json["PupilFitMethod"] = _extract_PupilFitMethod(df_ms_reduced)
     base_json["SamplingFrequency"] = _extract_SamplingFrequency(df_ms_reduced)
 
     base_json["StartTime"] = _extract_StartTime(events)
     base_json["StopTime"] = _extract_StopTime(events)
+
+    if base_json.has_calibration:
+        base_json["EyeTrackingMethod"] = _extract_EyeTrackingMethod(events)
 
     if base_json.two_eyes:
         metadata_eye1: dict[str, str | list[str] | list[float]] = {

--- a/tests/test_edf2bids.py
+++ b/tests/test_edf2bids.py
@@ -283,7 +283,6 @@ def test_extract_CalibrationUnit(folder, expected, eyelink_test_data_dir):
         ("pitracker", []),
         (
             "rest",
-            [
                 [
                     [960, 540],
                     [960, 732],
@@ -298,14 +297,12 @@ def test_extract_CalibrationUnit(folder, expected, eyelink_test_data_dir):
                     [1126, 636],
                     [794, 444],
                     [960, 348],
-                ]
-            ],
+                ],
         ),
         ("satf", []),
         ("vergence", []),
         (
             "2eyes",
-            [
                 [
                     [960, 540],
                     [960, 732],
@@ -320,8 +317,7 @@ def test_extract_CalibrationUnit(folder, expected, eyelink_test_data_dir):
                     [1126, 636],
                     [794, 444],
                     [960, 348],
-                ]
-            ],
+                ],
         ),
     ],
 )

--- a/tests/test_edf2bids.py
+++ b/tests/test_edf2bids.py
@@ -258,6 +258,7 @@ def test_extract_CalibrationUnit(folder, expected, eyelink_test_data_dir):
         ),
         (
             "rest",
+            [
                 [
                     [960, 540],
                     [960, 732],
@@ -273,9 +274,11 @@ def test_extract_CalibrationUnit(folder, expected, eyelink_test_data_dir):
                     [794, 444],
                     [960, 348],
                 ],
+            ]    
         ),
         (
             "2eyes",
+            [
                 [
                     [960, 540],
                     [960, 732],


### PR DESCRIPTION
make sure that EyeTrackingMethod is empty if no calibration because otherwise it writes wrong content into the variable. Now EyeTrackingMethod is empty/not shown in physio.json if no calibration. To test find example edf on osf, folder "no-calibration". 