### PR TITLE
add --force mode for metadata.yml file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         -   uses: actions/cache@v4
             id: cache
             with:
-                path: /home/runner/work/bids-standard/eye2bids/tests/data/osf
+                path: /home/runner/work/eye2bids/eye2bids/tests/data/osf
                 key: data
 
         -   name: Install data

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,14 @@ jobs:
         -   name: Install package
             run: pip install .[test]
 
+        -   uses: actions/cache@v4
+            id: cache
+            with:
+                path: /home/runner/work/bids-standard/eye2bids/tests/data/osf
+                key: data
+
         -   name: Install data
+            if: ${{ steps.cache.outputs.cache-hit != 'true' }}
             run: make test_data
 
         -   name: unit tests

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![test](https://github.com/bids-standard/eye2bids/actions/workflows/tests.yml/badge.svg)](https://github.com/bids-standard/eye2bids/actions/workflows/tests.yml)
+
 # eye2bids
 
 ## Installation

--- a/eye2bids/_cli.py
+++ b/eye2bids/_cli.py
@@ -55,4 +55,5 @@ def cli(argv: Sequence[str] = sys.argv) -> None:
         metadata_file=metadata_file,
         output_dir=output_dir,
         interactive=args.interactive,
+        force=args.force
     )

--- a/eye2bids/_cli.py
+++ b/eye2bids/_cli.py
@@ -55,5 +55,5 @@ def cli(argv: Sequence[str] = sys.argv) -> None:
         metadata_file=metadata_file,
         output_dir=output_dir,
         interactive=args.interactive,
-        force=args.force
+        force=args.force,
     )

--- a/eye2bids/_parser.py
+++ b/eye2bids/_parser.py
@@ -74,7 +74,8 @@ def global_parser() -> ArgumentParser:
         "-f",
         "--force",
         help="""
-        To run the converter without passing a metadata.yml file. Creates an invalid BIDS dataset.
+        To run the converter without passing a metadata.yml file.\n 
+        Creates an invalid BIDS dataset.
         """,
         action="store_true",
     )

--- a/eye2bids/_parser.py
+++ b/eye2bids/_parser.py
@@ -74,7 +74,7 @@ def global_parser() -> ArgumentParser:
         "-f",
         "--force",
         help="""
-        To run the converter without passing a metadata.yml file.\n 
+        To run the converter without passing a metadata.yml file.\n
         Creates an invalid BIDS dataset.
         """,
         action="store_true",

--- a/eye2bids/_parser.py
+++ b/eye2bids/_parser.py
@@ -70,4 +70,12 @@ def global_parser() -> ArgumentParser:
         type=int,
         nargs=2,
     )
+    parser.add_argument(
+        "-f",
+        "--force",
+        help="""
+        To run the converter without passing a metadata.yml file. Creates an invalid BIDS dataset.
+        """,
+        action="store_true",
+    )
     return parser

--- a/eye2bids/edf2bids.py
+++ b/eye2bids/edf2bids.py
@@ -45,7 +45,6 @@ def _check_inputs(
     else:
         raise FileNotFoundError(f"No such input file: {cheked_input_file}")
 
-    checked_metadata_file = None
     if metadata_file in [None, ""]:
         e2b_log.warning(
             """Load the metadata.yml file with the additional metadata.\n
@@ -59,16 +58,18 @@ def _check_inputs(
             if metadata_file in ["", None]:
                 if not force:
                     e2b_log.error(
-                        """You didn't pass a metadata.yml file. As this file contains metadata\n
-                which is REQUIRED for a valid BIDS dataset, the conversion process now\n
-                stops. Please start again with a metadata.yml file\n
-                or run eye2bids in force mode.\n
-                (will produce an invalid BIDS dataset).\n"""
+                        """You didn't pass a metadata.yml file.
+                        As this file contains metadata
+                        which is REQUIRED for a valid BIDS dataset,
+                        the conversion process now stops.
+                        Please start again with a metadata.yml file
+                        or run eye2bids in force mode.\n
+                        This will produce an invalid BIDS dataset.\n"""
                     )
                     raise SystemExit(1)
 
-
-    elif isinstance(metadata_file, str):
+    checked_metadata_file = None
+    if isinstance(metadata_file, str):
         checked_metadata_file = Path(metadata_file)
     elif isinstance(metadata_file, Path):
         checked_metadata_file = metadata_file

--- a/eye2bids/edf2bids.py
+++ b/eye2bids/edf2bids.py
@@ -47,8 +47,9 @@ def _check_inputs(
 
     if metadata_file in [None, ""]:
         e2b_log.info(
-            """Load the metadata.yml file with the additional metadata (find a template in the eye2bids GitHub).\n
-            This file must contain at least the additional REQUIRED metadata
+            """Load the metadata.yml file with the additional metadata.\n 
+            You can find a template in the eye2bids GitHub.\n
+            This file must contain at least the additional REQUIRED metadata\n
             in the format specified in the BIDS specification.\n"""
         )
         metadata_file = Prompt.ask("Enter the file path to the metadata.yml file")
@@ -57,7 +58,8 @@ def _check_inputs(
             e2b_log.info(
                 """You didn't pass a metadata.yml file. As this file contains metadata\n
                 which is REQUIRED for a valid BIDS dataset, the conversion process now\n
-                stops. Please start again with a metadata.yml file or run eye2bids in force mode.\n
+                stops. Please start again with a metadata.yml file\n 
+                or run eye2bids in force mode.\n
                 (will produce an invalid BIDS dataset).\n"""
             )
             raise SystemExit(1)

--- a/eye2bids/edf2bids.py
+++ b/eye2bids/edf2bids.py
@@ -45,6 +45,7 @@ def _check_inputs(
     else:
         raise FileNotFoundError(f"No such input file: {cheked_input_file}")
 
+    checked_metadata_file = None
     if metadata_file in [None, ""]:
         e2b_log.warning(
             """Load the metadata.yml file with the additional metadata.\n
@@ -66,7 +67,6 @@ def _check_inputs(
                     )
                     raise SystemExit(1)
 
-                checked_metadata_file = None
 
     elif isinstance(metadata_file, str):
         checked_metadata_file = Path(metadata_file)

--- a/eye2bids/edf2bids.py
+++ b/eye2bids/edf2bids.py
@@ -54,19 +54,19 @@ def _check_inputs(
         )
 
         if interactive:
-          metadata_file = Prompt.ask("Enter the file path to the metadata.yml file")
-          if metadata_file in ["", None]:
-            if not force:
-              e2b_log.error(
-                """You didn't pass a metadata.yml file. As this file contains metadata\n
+            metadata_file = Prompt.ask("Enter the file path to the metadata.yml file")
+            if metadata_file in ["", None]:
+                if not force:
+                    e2b_log.error(
+                        """You didn't pass a metadata.yml file. As this file contains metadata\n
                 which is REQUIRED for a valid BIDS dataset, the conversion process now\n
                 stops. Please start again with a metadata.yml file\n
                 or run eye2bids in force mode.\n
                 (will produce an invalid BIDS dataset).\n"""
-            )
-              raise SystemExit(1)
+                    )
+                    raise SystemExit(1)
 
-            checked_metadata_file = None
+                checked_metadata_file = None
 
     elif isinstance(metadata_file, str):
         checked_metadata_file = Path(metadata_file)

--- a/eye2bids/edf2bids.py
+++ b/eye2bids/edf2bids.py
@@ -46,25 +46,26 @@ def _check_inputs(
         raise FileNotFoundError(f"No such input file: {cheked_input_file}")
 
     if metadata_file in [None, ""]:
-        e2b_log.info(
+        e2b_log.warning(
             """Load the metadata.yml file with the additional metadata.\n
             You can find a template in the eye2bids GitHub.\n
             This file must contain at least the additional REQUIRED metadata\n
             in the format specified in the BIDS specification.\n"""
         )
-        metadata_file = Prompt.ask("Enter the file path to the metadata.yml file")
 
-        if metadata_file in ["", None] and not force:
-            e2b_log.info(
+        if interactive:
+          metadata_file = Prompt.ask("Enter the file path to the metadata.yml file")
+          if metadata_file in ["", None]:
+            if not force:
+              e2b_log.error(
                 """You didn't pass a metadata.yml file. As this file contains metadata\n
                 which is REQUIRED for a valid BIDS dataset, the conversion process now\n
                 stops. Please start again with a metadata.yml file\n
                 or run eye2bids in force mode.\n
                 (will produce an invalid BIDS dataset).\n"""
             )
-            raise SystemExit(1)
+              raise SystemExit(1)
 
-        elif metadata_file in ["", None] and force:
             checked_metadata_file = None
 
     elif isinstance(metadata_file, str):

--- a/eye2bids/edf2bids.py
+++ b/eye2bids/edf2bids.py
@@ -45,28 +45,32 @@ def _check_inputs(
     else:
         raise FileNotFoundError(f"No such input file: {cheked_input_file}")
 
-    if metadata_file in [None, ""]:
+    if metadata_file in [None, ""] and interactive:
         e2b_log.warning(
             """Load the metadata.yml file with the additional metadata.\n
             You can find a template in the eye2bids GitHub.\n
             This file must contain at least the additional REQUIRED metadata\n
             in the format specified in the BIDS specification.\n"""
         )
+        metadata_file = Prompt.ask("Enter the file path to the metadata.yml file")
 
-        if interactive:
-            metadata_file = Prompt.ask("Enter the file path to the metadata.yml file")
-            if metadata_file in ["", None]:
-                if not force:
-                    e2b_log.error(
-                        """You didn't pass a metadata.yml file.
-                        As this file contains metadata
-                        which is REQUIRED for a valid BIDS dataset,
-                        the conversion process now stops.
-                        Please start again with a metadata.yml file
-                        or run eye2bids in force mode.\n
-                        This will produce an invalid BIDS dataset.\n"""
-                    )
-                    raise SystemExit(1)
+    if metadata_file in [None, ""]:
+        if not force:
+            e2b_log.error(
+                """You didn't pass a metadata.yml file.
+                As this file contains metadata
+                which is REQUIRED for a valid BIDS dataset,
+                the conversion process now stops.
+                Please start again with a metadata.yml file
+                or run eye2bids in --force mode.\n
+                This will produce an invalid BIDS dataset.\n"""
+            )
+            raise SystemExit(1)
+        else:
+            e2b_log.warning(
+                """You didn't pass a metadata.yml file.
+                    Note that this will produce an invalid BIDS dataset.\n"""
+            )
 
     checked_metadata_file = None
     if isinstance(metadata_file, str):

--- a/eye2bids/edf2bids.py
+++ b/eye2bids/edf2bids.py
@@ -47,7 +47,7 @@ def _check_inputs(
 
     if metadata_file in [None, ""]:
         e2b_log.info(
-            """Load the metadata.yml file with the additional metadata.\n 
+            """Load the metadata.yml file with the additional metadata.\n
             You can find a template in the eye2bids GitHub.\n
             This file must contain at least the additional REQUIRED metadata\n
             in the format specified in the BIDS specification.\n"""
@@ -58,7 +58,7 @@ def _check_inputs(
             e2b_log.info(
                 """You didn't pass a metadata.yml file. As this file contains metadata\n
                 which is REQUIRED for a valid BIDS dataset, the conversion process now\n
-                stops. Please start again with a metadata.yml file\n 
+                stops. Please start again with a metadata.yml file\n
                 or run eye2bids in force mode.\n
                 (will produce an invalid BIDS dataset).\n"""
             )

--- a/eye2bids/edf2bids.py
+++ b/eye2bids/edf2bids.py
@@ -59,12 +59,12 @@ def _check_inputs(
                 which is REQUIRED for a valid BIDS dataset, the conversion process now\n
                 stops. Please start again with a metadata.yml file or run eye2bids in force mode.\n
                 (will produce an invalid BIDS dataset).\n"""
-                )
+            )
             raise SystemExit(1)
-        
+
         elif metadata_file in ["", None] and force:
             checked_metadata_file = None
-        
+
     elif isinstance(metadata_file, str):
         checked_metadata_file = Path(metadata_file)
     elif isinstance(metadata_file, Path):
@@ -495,7 +495,7 @@ def edf2bids(
     metadata_file: str | Path | None = None,
     output_dir: str | Path | None = None,
     interactive: bool = False,
-    force: bool = False
+    force: bool = False,
 ) -> None:
     """Convert edf to tsv + json."""
     if not _check_edf2asc_present():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,6 @@ module = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-ra -q -vv --cov eye2bids"
+addopts = "-ra -q -vv --cov eye2bids --durations=0"
 norecursedirs = "data"
 testpaths = ["tests/"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ def root_dir() -> Path:
 @pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
 @pytest.mark.parametrize("output_dir", [data_dir() / "output", None])
 @pytest.mark.parametrize("use_relative_path", [False, True])
-def test_edf_cli(use_relative_path, metadata_file, output_dir, eyelink_test_data_dir):
+def test_edf_cli(use_relative_path, output_dir, eyelink_test_data_dir):
 
     metadata_file = data_dir() / "metadata.yml"
 
@@ -27,14 +27,14 @@ def test_edf_cli(use_relative_path, metadata_file, output_dir, eyelink_test_data
 
     if use_relative_path:
         input_file = input_file.relative_to(root_dir())
+        metadata_file = metadata_file.relative_to(root_dir())
 
-    command = ["eye2bids", "--input_file", str(input_file)]
-    if metadata_file is not None:
-        if use_relative_path:
-            metadata_file = metadata_file.relative_to(root_dir())
-        metadata_file = str(metadata_file)
-        command.extend(["--metadata_file", metadata_file])
-
+    command = [
+        "eye2bids",
+        "--input_file",
+        str(input_file),
+        *["--metadata_file", str(metadata_file)],
+    ]
     if output_dir is not None:
         if use_relative_path:
             output_dir = output_dir.relative_to(root_dir())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,10 +16,12 @@ def root_dir() -> Path:
 
 
 @pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
-@pytest.mark.parametrize("metadata_file", [data_dir() / "metadata.yml", None])
 @pytest.mark.parametrize("output_dir", [data_dir() / "output", None])
 @pytest.mark.parametrize("use_relative_path", [False, True])
 def test_edf_cli(use_relative_path, metadata_file, output_dir, eyelink_test_data_dir):
+
+    metadata_file = data_dir() / "metadata.yml"
+
     input_dir = eyelink_test_data_dir / "satf"
     input_file = edf_test_files(input_dir=input_dir)[0]
 
@@ -53,5 +55,6 @@ def test_all_edf_files(input_file):
         str(input_file),
         "--output_dir",
         str(data_dir() / "output"),
+        "--force",
     ]
     cli(command)

--- a/tests/test_edf2bids.py
+++ b/tests/test_edf2bids.py
@@ -186,7 +186,7 @@ def test_number_columns_1eye_tsv(eyelink_test_data_dir):
     output_dir = data_dir() / "output"
     output_dir.mkdir(exist_ok=True)
 
-    edf2bids(input_file=input_file, output_dir=output_dir, force=False)
+    edf2bids(input_file=input_file, output_dir=output_dir, force=True)
 
     expected_eyetrack_tsv = output_dir / f"{input_file.stem}_recording-eye1_physio.tsv.gz"
     df = pd.read_csv(expected_eyetrack_tsv, sep="\t")
@@ -490,7 +490,7 @@ def test_number_columns_physioevents_tsv(eyelink_test_data_dir):
     output_dir = data_dir() / "output"
     output_dir.mkdir(exist_ok=True)
 
-    edf2bids(input_file=input_file, output_dir=output_dir, force=False)
+    edf2bids(input_file=input_file, output_dir=output_dir, force=True)
 
     expected_physioevents_tsv = (
         output_dir / f"{input_file.stem}_recording-eye2_physioevents.tsv.gz"

--- a/tests/test_edf2bids.py
+++ b/tests/test_edf2bids.py
@@ -48,8 +48,9 @@ def _check_output_exists(output_dir, input_file, eye=1):
 
 
 @pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
-@pytest.mark.parametrize("metadata_file", [data_dir() / "metadata.yml", None])
-def test_edf_end_to_end(metadata_file, eyelink_test_data_dir):
+def test_edf_end_to_end(eyelink_test_data_dir):
+    metadata_file = data_dir() / "metadata.yml"
+
     input_dir = eyelink_test_data_dir / "satf"
     input_file = edf_test_files(input_dir=input_dir)[0]
 
@@ -75,8 +76,28 @@ def test_edf_end_to_end(metadata_file, eyelink_test_data_dir):
 
 
 @pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
-@pytest.mark.parametrize("metadata_file", [data_dir() / "metadata.yml", None])
-def test_edf_end_to_end_2eyes(metadata_file, eyelink_test_data_dir):
+def test_edf_end_to_end_error_no_metadata(eyelink_test_data_dir):
+    input_dir = eyelink_test_data_dir / "satf"
+    input_file = edf_test_files(input_dir=input_dir)[0]
+
+    output_dir = data_dir() / "output"
+    output_dir.mkdir(exist_ok=True)
+
+    # when force is true no system exit even with no metadata file
+    edf2bids(input_file=input_file, metadata_file=None, output_dir=output_dir, force=True)
+    # but when force is false, no metadata file triggers a failure
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        edf2bids(
+            input_file=input_file, metadata_file=None, output_dir=output_dir, force=False
+        )
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
+
+
+@pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
+def test_edf_end_to_end_2eyes(eyelink_test_data_dir):
+    metadata_file = data_dir() / "metadata.yml"
+
     input_dir = eyelink_test_data_dir / "2eyes"
     input_file = edf_test_files(input_dir=input_dir)[0]
 

--- a/tests/test_edf2bids.py
+++ b/tests/test_edf2bids.py
@@ -186,7 +186,7 @@ def test_number_columns_1eye_tsv(eyelink_test_data_dir):
     output_dir = data_dir() / "output"
     output_dir.mkdir(exist_ok=True)
 
-    edf2bids(input_file=input_file, output_dir=output_dir)
+    edf2bids(input_file=input_file, output_dir=output_dir, force=False)
 
     expected_eyetrack_tsv = output_dir / f"{input_file.stem}_recording-eye1_physio.tsv.gz"
     df = pd.read_csv(expected_eyetrack_tsv, sep="\t")
@@ -490,7 +490,7 @@ def test_number_columns_physioevents_tsv(eyelink_test_data_dir):
     output_dir = data_dir() / "output"
     output_dir.mkdir(exist_ok=True)
 
-    edf2bids(input_file=input_file, output_dir=output_dir)
+    edf2bids(input_file=input_file, output_dir=output_dir, force=False)
 
     expected_physioevents_tsv = (
         output_dir / f"{input_file.stem}_recording-eye2_physioevents.tsv.gz"

--- a/tests/test_edf2bids.py
+++ b/tests/test_edf2bids.py
@@ -77,7 +77,7 @@ def test_edf_end_to_end(eyelink_test_data_dir):
 
 @pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
 def test_edf_end_to_end_error_no_metadata(eyelink_test_data_dir):
-    input_dir = eyelink_test_data_dir / "satf"
+    input_dir = eyelink_test_data_dir / "2eyes"
     input_file = edf_test_files(input_dir=input_dir)[0]
 
     output_dir = data_dir() / "output"
@@ -144,7 +144,7 @@ def test_edf_nan_in_tsv(eyelink_test_data_dir):
     output_dir = data_dir() / "output"
     output_dir.mkdir(exist_ok=True)
 
-    edf2bids(input_file=input_file, output_dir=output_dir)
+    edf2bids(input_file=input_file, output_dir=output_dir, force=True)
 
     expected_eyetrack_tsv = output_dir / f"{input_file.stem}_recording-eye1_physio.tsv.gz"
     df = pd.read_csv(expected_eyetrack_tsv, sep="\t", header=None)
@@ -165,7 +165,7 @@ def test_number_columns_2eyes_tsv(eyelink_test_data_dir):
     output_dir = data_dir() / "output"
     output_dir.mkdir(exist_ok=True)
 
-    edf2bids(input_file=input_file, output_dir=output_dir)
+    edf2bids(input_file=input_file, output_dir=output_dir, force=True)
 
     expected_eyetrack_tsv = output_dir / f"{input_file.stem}_recording-eye1_physio.tsv.gz"
     df = pd.read_csv(expected_eyetrack_tsv, sep="\t")
@@ -549,7 +549,7 @@ def test_physioevents_value(folder, expected, eyelink_test_data_dir):
     output_dir = data_dir() / "output"
     output_dir.mkdir(exist_ok=True)
 
-    edf2bids(input_file=input_file, output_dir=output_dir)
+    edf2bids(input_file=input_file, output_dir=output_dir, force=True)
 
     expected_eyetrackphysio_tsv = (
         output_dir / f"{input_file.stem}_recording-eye1_physioevents.tsv.gz"

--- a/tools/download_test_data.py
+++ b/tools/download_test_data.py
@@ -15,6 +15,8 @@ root_dir = Path(__file__).parent.parent
 
 output_dir = root_dir / "tests" / "data" / "osf"
 
+print(f"Saving files to {output_dir}")
+
 if output_dir.exists():
     shutil.rmtree(output_dir)
 output_dir.mkdir(parents=True)


### PR DESCRIPTION
Modification: so far it was ok not to pass a metadata.yml file. However, this file contains required metadata. Now the program stops if no metadata.yml file was passed and gives information on why the program stopped and how to fix that. Additionally, now it hase a `--force` flag where Users can still convert their edfs without passing a metadata.yml file. The user is then informed that the resulting dataset is invalid to BIDS.

Closes #83 
