### PR TITLE
Modify metadata.yml according to #99 and #103

### DIFF
--- a/eye2bids/config/eyelink_metadata.yml
+++ b/eye2bids/config/eyelink_metadata.yml
@@ -10,18 +10,18 @@
 SampleCoordinateUnits: str
 SampleCoordinateSystem: str
 EnvironmentCoordinates: str
-ScreenDistance: float # or express as X,Y,Z coordinates, e.g. [0.05, 0.30, 0.40]
-ScreenRefreshRate: int
-ScreenSize: [float]
 
 # Recommended (leave empty if not available but put information you want to share with your dataset here!):
 SoftwareVersion: str
+ScreenRefreshRate: int
+ScreenSize: [float]
 ScreenAOIDefinition: [str, [int]]
 EyeCameraSettings:
+ScreenDistance: float # or express as X,Y,Z coordinates, e.g. [0.05, 0.30, 0.40]
 EyeTrackerDistance: float # or express as X,Y,Z coordinates, e.g. [0.05, 0.30, 0.40]
 FeatureDetectionSettings:
 GazeMappingSettings:
-RawDataFilters:
+RawDataFilters: str
 InstitutionName: str
 InstitutionAddress: str
 TaskName: str

--- a/eye2bids/config/eyelink_metadata.yml
+++ b/eye2bids/config/eyelink_metadata.yml
@@ -4,22 +4,24 @@
 # https://bids-specification--1128.org.readthedocs.build/en/1128/modality-specific-files/eye-tracking.html
 # Please go through the specification
 # and fill the fields below according to the data types given in the specification.
+# !Note that ScreenSize and EyeTrackerDistance units are in meter, not centimeter!
 
 # REQUIRED, fill according to BIDS specification (!the converter will not run successfully if you leave this empty!):
-SampleCoordinateUnits: pixel
-SampleCoordinateSystem: gaze-on-screen
-EnvironmentCoordinates: top-left
-ScreenDistance: 60
-ScreenRefreshRate: 60
-ScreenSize: [0.386, 0.29]
+SampleCoordinateUnits: str
+SampleCoordinateSystem: str
+EnvironmentCoordinates: str
+ScreenDistance: float # or express as X,Y,Z coordinates, e.g. [0.05, 0.30, 0.40]
+ScreenRefreshRate: int
+ScreenSize: [float]
 
 # Recommended (leave empty if not available but put information you want to share with your dataset here!):
-SoftwareVersion: SREB1.10.1630 WIN32 LID:F2AE011 Mod:2017.04.21 15:19 CEST
-ScreenAOIDefinition: [square, [00, 150, 300, 350]]
+SoftwareVersion: str
+ScreenAOIDefinition: [str, [int]]
 EyeCameraSettings:
-EyeTrackerDistance:
+EyeTrackerDistance: float # or express as X,Y,Z coordinates, e.g. [0.05, 0.30, 0.40]
 FeatureDetectionSettings:
 GazeMappingSettings:
 RawDataFilters:
-InstitutionName: Philipps-University Marburg
-InstitutionAddress: Gutenbergstr. 18
+InstitutionName: str
+InstitutionAddress: str
+TaskName: str

--- a/tests/data/eyelink_metadata.yml
+++ b/tests/data/eyelink_metadata.yml
@@ -4,24 +4,22 @@
 # https://bids-specification--1128.org.readthedocs.build/en/1128/modality-specific-files/eye-tracking.html
 # Please go through the specification
 # and fill the fields below according to the data types given in the specification.
-# !Note that ScreenSize and EyeTrackerDistance units are in meter, not centimeter!
 
 # REQUIRED, fill according to BIDS specification (!the converter will not run successfully if you leave this empty!):
-SampleCoordinateUnits: str
-SampleCoordinateSystem: str
-EnvironmentCoordinates: str
-ScreenDistance: int
-ScreenRefreshRate: int
-ScreenSize: [float]
+SampleCoordinateUnits: pixel
+SampleCoordinateSystem: gaze-on-screen
+EnvironmentCoordinates: top-left
+ScreenDistance: 0.6
+ScreenRefreshRate: 60
+ScreenSize: [0.386, 0.29]
 
 # Recommended (leave empty if not available but put information you want to share with your dataset here!):
-SoftwareVersion: str
-ScreenAOIDefinition: [str, [int]]
+SoftwareVersion: SREB1.10.1630 WIN32 LID:F2AE011 Mod:2017.04.21 15:19 CEST
+ScreenAOIDefinition: [square, [00, 150, 300, 350]]
 EyeCameraSettings:
-EyeTrackerDistance: float
+EyeTrackerDistance:
 FeatureDetectionSettings:
 GazeMappingSettings:
 RawDataFilters:
-InstitutionName: str
-InstitutionAddress: str
-TaskName: str
+InstitutionName: Philipps-University Marburg
+InstitutionAddress: Gutenbergstr. 18

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def root_dir() -> Path:
 @pytest.mark.parametrize("output_dir", [data_dir() / "output", None])
 @pytest.mark.parametrize("use_relative_path", [False, True])
 def test_edf_cli(use_relative_path, output_dir, eyelink_test_data_dir):
-    metadata_file = data_dir() / "metadata.yml"
+    metadata_file = data_dir() / "eyelink_metadata.yml"
 
     input_dir = eyelink_test_data_dir / "satf"
     input_file = edf_test_files(input_dir=input_dir)[0]

--- a/tests/test_edf2bids.py
+++ b/tests/test_edf2bids.py
@@ -89,7 +89,7 @@ def _check_output_content(output_dir, input_file, eye=1):
 @pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
 def test_edf_end_to_end_all(eyelink_test_data_dir, folder):
     """Run conversion of all test datasets and check output."""
-    metadata_file = data_dir() / "metadata.yml"
+    metadata_file = data_dir() / "eyelink_metadata.yml"
 
     input_dir = eyelink_test_data_dir / folder
     input_file = edf_test_files(input_dir=input_dir)[0]
@@ -111,7 +111,7 @@ def test_edf_end_to_end_all(eyelink_test_data_dir, folder):
 @pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
 def test_edf_end_to_end_emg_xfail(eyelink_test_data_dir, folder):
     """Run conversion of all test datasets and check output."""
-    metadata_file = data_dir() / "metadata.yml"
+    metadata_file = data_dir() / "eyelink_metadata.yml"
 
     input_dir = eyelink_test_data_dir / folder
     input_file = edf_test_files(input_dir=input_dir)[0]
@@ -128,7 +128,7 @@ def test_edf_end_to_end_emg_xfail(eyelink_test_data_dir, folder):
 @pytest.mark.xfail(reason="Output is not a continuous recording. See #69.")
 @pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
 def test_edf_end_to_end(eyelink_test_data_dir):
-    metadata_file = data_dir() / "metadata.yml"
+    metadata_file = data_dir() / "eyelink_metadata.yml"
 
     input_dir = eyelink_test_data_dir / "satf"
     input_file = edf_test_files(input_dir=input_dir)[0]
@@ -175,7 +175,7 @@ def test_edf_end_to_end_error_no_metadata(eyelink_test_data_dir):
 
 @pytest.mark.skipif(not _check_edf2asc_present(), reason="edf2asc missing")
 def test_edf_end_to_end_2eyes(eyelink_test_data_dir):
-    metadata_file = data_dir() / "metadata.yml"
+    metadata_file = data_dir() / "eyelink_metadata.yml"
 
     input_dir = eyelink_test_data_dir / "2eyes"
     input_file = edf_test_files(input_dir=input_dir)[0]


### PR DESCRIPTION
- change name to "eyelink_metadata.yml" so that it has a unique name for 1. ezBIDS to look for in a folder and 2. for EyeLink because other eyetrackers will have other missing metadata and need their own file for the manual metadata
- change tests to look for new filename
- include commit [6e787b6](https://github.com/bids-standard/bids-specification/commit/6e787b6d6d129383038d4d4a87683285760c01f2#diff-9c80bef9a8601b9410f41180bfb2631eee51fb67e7f5727ca0be4e4dfc99d844R1208) of metadata schema from bids specification

closes #99 
closes #103 
