### PR TITLE
updates according to issues #119 and #120 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ pip install .
 ### Run code
 
 ```bash
-eye2bids --input_file INPUT_FILE
+eye2bids --input_file INPUT_FILE --metadata_file METADATA_FILE
 ```
 
-    Usage: eye2bids [-h] [-v] --input_file INPUT_FILE [--metadata_file METADATA_FILE] [--output_dir OUTPUT_DIR] [-i] [--verbosity {0,1,2,3}]
+    Usage: eye2bids [-h] [-v] --input_file INPUT_FILE --metadata_file METADATA_FILE [--output_dir OUTPUT_DIR] [-i] [--verbosity {0,1,2,3}]
                     [--input_type INPUT_TYPE]
 
     Converts eyetracking data to a BIDS compatible format.

--- a/eye2bids/_base.py
+++ b/eye2bids/_base.py
@@ -126,32 +126,41 @@ class BasePhysioJson(dict[str, Any]):
     has_calibration: bool
 
     def __init__(self, manufacturer: str, metadata: dict[str, Any] | None = None) -> None:
+        self.update_from_metadata(metadata)
+
         self["Manufacturer"] = manufacturer
         self["PhysioType"] = "eyetrack"
 
         self["Columns"] = ["timestamp", "x_coordinate", "y_coordinate", "pupil_size"]
         self["timestamp"] = {
             "Description": (
-                "Timestamp issued by the eye-tracker "
-                "indexing the continuous recordings "
-                "corresponding to the sampled eye."
-            )
+                "a continuously increasing "
+                "identifier of the sampling "
+                "time registered by the device"
+            ),
+            "Units": ("ms"),
+            "Origin": ("System startup"),
         }
+
+        units = self["Units"]
+
         self["x_coordinate"] = {
+            "LongName": ("Gaze position (x)"),
             "Description": (
                 "Gaze position x-coordinate of the recorded eye, "
                 "in the coordinate units specified "
                 "in the corresponding metadata sidecar."
             ),
-            "Units": "a.u.",
+            "Units": units,
         }
         self["y_coordinate"] = {
+            "LongName": ("Gaze position (y)"),
             "Description": (
                 "Gaze position y-coordinate of the recorded eye, "
                 "in the coordinate units specified "
                 "in the corresponding metadata sidecar."
             ),
-            "Units": "a.u.",
+            "Units": units,
         }
         self["pupil_size"] = {
             "Description": (
@@ -162,13 +171,12 @@ class BasePhysioJson(dict[str, Any]):
             "Units": "a.u.",
         }
 
-        self.update_from_metadata(metadata)
-
     def update_from_metadata(self, metadata: None | dict[str, Any] = None) -> None:
         """Update content of json side car based on metadata."""
         if metadata is None:
             return None
 
+        self["Units"] = metadata.get("Units")
         self["SoftwareVersion"] = metadata.get("SoftwareVersion")
         self["EyeCameraSettings"] = metadata.get("EyeCameraSettings")
         self["EyeTrackerDistance"] = metadata.get("EyeTrackerDistance")
@@ -176,7 +184,6 @@ class BasePhysioJson(dict[str, Any]):
         self["GazeMappingSettings"] = metadata.get("GazeMappingSettings")
         self["RawDataFilters"] = metadata.get("RawDataFilters")
         self["SampleCoordinateSystem"] = metadata.get("SampleCoordinateSystem")
-        self["SampleCoordinateUnits"] = metadata.get("SampleCoordinateUnits")
         self["ScreenAOIDefinition"] = metadata.get("ScreenAOIDefinition")
 
     def output_filename(self, recording: str | None = None) -> str:

--- a/eye2bids/config/eyelink_metadata.yml
+++ b/eye2bids/config/eyelink_metadata.yml
@@ -7,11 +7,12 @@
 # !Note that ScreenSize and EyeTrackerDistance units are in meter, not centimeter!
 
 # REQUIRED, fill according to BIDS specification (!the converter will not run successfully if you leave this empty!):
-SampleCoordinateUnits: str
 SampleCoordinateSystem: str
 EnvironmentCoordinates: str
+Units: str
 
-# Recommended (leave empty if not available but put information you want to share with your dataset here!):
+# Recommended or optional (leave empty if not available but put information you want to share with your dataset here!):
+CalibrationPosition: [[int, int]]
 SoftwareVersion: str
 ScreenRefreshRate: int
 ScreenSize: [float]

--- a/tests/data/eyelink_metadata.yml
+++ b/tests/data/eyelink_metadata.yml
@@ -6,12 +6,9 @@
 # and fill the fields below according to the data types given in the specification.
 
 # REQUIRED, fill according to BIDS specification (!the converter will not run successfully if you leave this empty!):
-SampleCoordinateUnits: pixel
+Units: pixel
 SampleCoordinateSystem: gaze-on-screen
 EnvironmentCoordinates: top-left
-ScreenDistance: 0.6
-ScreenRefreshRate: 60
-ScreenSize: [0.386, 0.29]
 
 # Recommended (leave empty if not available but put information you want to share with your dataset here!):
 SoftwareVersion: SREB1.10.1630 WIN32 LID:F2AE011 Mod:2017.04.21 15:19 CEST
@@ -23,3 +20,6 @@ GazeMappingSettings:
 RawDataFilters:
 InstitutionName: Philipps-University Marburg
 InstitutionAddress: Gutenbergstr. 18
+ScreenDistance: 0.6
+ScreenRefreshRate: 60
+ScreenSize: [0.386, 0.29]

--- a/tests/test_edf2bids.py
+++ b/tests/test_edf2bids.py
@@ -10,9 +10,7 @@ from eye2bids.edf2bids import (
     _check_edf2asc_present,
     _convert_edf_to_asc_events,
     _extract_AverageCalibrationError,
-    _extract_CalibrationPosition,
     _extract_CalibrationType,
-    _extract_CalibrationUnit,
     _extract_DeviceSerialNumber,
     _extract_EyeTrackingMethod,
     _extract_ManufacturersModelName,
@@ -308,100 +306,6 @@ def test_extract_ScreenResolution(folder, expected, eyelink_test_data_dir):
     asc_file = asc_test_files(input_dir=input_dir, suffix="*_events")[0]
     df_ms_reduced = _load_asc_file_as_reduced_df(asc_file)
     assert _extract_ScreenResolution(df_ms_reduced) == expected
-
-
-@pytest.mark.parametrize(
-    "folder, expected",
-    [
-        ("lt", "pixel"),
-        ("rest", "pixel"),
-        ("2eyes", "pixel"),
-    ],
-)
-def test_extract_CalibrationUnit(folder, expected, eyelink_test_data_dir):
-    input_dir = eyelink_test_data_dir / folder
-    asc_file = asc_test_files(input_dir=input_dir, suffix="*_events")[0]
-    df_ms_reduced = _load_asc_file_as_reduced_df(asc_file)
-    assert _extract_CalibrationUnit(df_ms_reduced) == expected
-
-
-@pytest.mark.parametrize(
-    "folder, expected",
-    [
-        (
-            "lt",
-            [
-                [
-                    [960, 540],
-                    [960, 324],
-                    [960, 755],
-                    [576, 540],
-                    [1343, 540],
-                    [622, 350],
-                    [1297, 350],
-                    [622, 729],
-                    [1297, 729],
-                ],
-                [
-                    [960, 540],
-                    [960, 324],
-                    [960, 755],
-                    [576, 540],
-                    [1343, 540],
-                    [622, 350],
-                    [1297, 350],
-                    [622, 729],
-                    [1297, 729],
-                ],
-            ],
-        ),
-        (
-            "rest",
-            [
-                [
-                    [960, 540],
-                    [960, 732],
-                    [1126, 444],
-                    [576, 540],
-                    [1344, 540],
-                    [768, 873],
-                    [1152, 873],
-                    [768, 207],
-                    [1152, 207],
-                    [794, 636],
-                    [1126, 636],
-                    [794, 444],
-                    [960, 348],
-                ],
-            ],
-        ),
-        (
-            "2eyes",
-            [
-                [
-                    [960, 540],
-                    [960, 732],
-                    [1126, 444],
-                    [576, 540],
-                    [1344, 540],
-                    [768, 873],
-                    [1152, 873],
-                    [768, 207],
-                    [1152, 207],
-                    [794, 636],
-                    [1126, 636],
-                    [794, 444],
-                    [960, 348],
-                ],
-            ],
-        ),
-    ],
-)
-def test_extract_CalibrationPosition(folder, expected, eyelink_test_data_dir):
-    input_dir = eyelink_test_data_dir / folder
-    asc_file = asc_test_files(input_dir=input_dir, suffix="*_events")[0]
-    df_ms_reduced = _load_asc_file_as_reduced_df(asc_file)
-    assert _extract_CalibrationPosition(df_ms_reduced) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #119 and #120 

- delete SampleCoordinateUnits from eyelink_metadata.yml
- insert Units for x-/y-coordinate in eyelink_metadata.yml as required metadata; user needs to enter them manually because I can only read it from eyelink-asc if there was a validation and not everyone does validation 
- delete function to read calibration positions from asc, since these are not the actual calibration positions and user should enter them manually
- insert CalibrationPosition in eyelink_metadata.yml as recommended metadata for the user to enter manually
- check confirmed: all messages including extra calibrations are saved in physioevents.tsv
- update metadata descriptions in physio.json
- update README, because it is mandatory to pass a metadata.yml file
